### PR TITLE
Add optional language field to email send

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,36 @@ await mailerSend.email.send(emailParams);
 
 ```
 
+### Send a template-based email in a specific language
+
+The optional `language` field accepts a language code (for example `de`, `fr`, `pt-BR`). It only applies to template-based sends and is ignored for raw HTML/text emails. Supported values: `de`, `en`, `es`, `fr`, `it`, `lt`, `nl`, `pl`, `pt-BR`.
+
+```js
+import 'dotenv/config';
+import { MailerSend, EmailParams, Sender, Recipient } from "mailersend";
+
+const mailerSend = new MailerSend({
+  apiKey: process.env.API_KEY,
+});
+
+const sentFrom = new Sender("you@yourdomain.com", "Your name");
+
+const recipients = [
+  new Recipient("your@client.com", "Your Client")
+];
+
+const emailParams = new EmailParams()
+  .setFrom(sentFrom)
+  .setTo(recipients)
+  .setReplyTo(sentFrom)
+  .setSubject("This is a Subject")
+  .setTemplateId('templateId')
+  .setLanguage("de");
+
+await mailerSend.email.send(emailParams);
+
+```
+
 ### Personalization
 
 ```js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailersend",
-  "version": "2.8.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailersend",
-      "version": "2.8.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "gaxios": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailersend",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Node.js helper module for MailerSend API",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/src/__tests__/modules/Email.test.ts
+++ b/src/__tests__/modules/Email.test.ts
@@ -125,6 +125,31 @@ describe("Email Module", () => {
     expect(result.statusCode).toBe(202);
   });
 
+  it("send email with language", async () => {
+    nock("http://test.com")
+      .post("/email", (body: any) => body.template_id === "tmpl_abc123" && body.language === "de")
+      .reply(202, {}, {});
+    const emailParams = new EmailParams()
+      .setTo([new Recipient("some_recipient@mail.com")])
+      .setTemplateId("tmpl_abc123")
+      .setLanguage("de");
+    const result = await emailModule.send(emailParams);
+    expect(result.statusCode).toBe(202);
+  });
+
+  it("send email omits language when not set", async () => {
+    nock("http://test.com")
+      .post("/email", (body: any) => !("language" in body))
+      .reply(202, {}, {});
+    const emailParams = new EmailParams()
+      .setFrom({ email: "some@email.com" })
+      .setTo([new Recipient("some_recipient@mail.com")])
+      .setSubject("Some subject")
+      .setText("Some text");
+    const result = await emailModule.send(emailParams);
+    expect(result.statusCode).toBe(202);
+  });
+
   it("send email with cc", async () => {
     const cc = [new Recipient("cc@example.com", "CC Person")];
     nock("http://test.com")

--- a/src/models/email/EmailParams.ts
+++ b/src/models/email/EmailParams.ts
@@ -16,6 +16,7 @@ export class EmailParams {
   send_at?: number | string;
   attachments?: Attachment[];
   template_id?: string;
+  language?: string;
   in_reply_to?: string;
   references?: string[];
   tags?: string[];
@@ -39,6 +40,7 @@ export class EmailParams {
     this.send_at = config?.sendAt;
     this.attachments = config?.attachments;
     this.template_id = config?.templateId;
+    this.language = config?.language;
     this.tags = config?.tags;
     this.personalization = config?.personalization;
     this.references = config?.references;
@@ -110,6 +112,11 @@ export class EmailParams {
 
   setTemplateId(id: string): EmailParams {
     this.template_id = id;
+    return this;
+  }
+
+  setLanguage(language: string): EmailParams {
+    this.language = language;
     return this;
   }
 


### PR DESCRIPTION
resolves [MSD-14489](https://linear.app/mailerlite/issue/MSD-14489/document-language-field-on-email-send-api-and-sdks)

Surfaces the new optional `language` field from the API's template-translations feature (MSD-14341) in the SDK.

### Changelist
- Add an optional `language` parameter to the email-send builder/params (e.g. `setLanguage("de")` / `.language("de")`), mirroring how `template_id` is handled.
- Include `language` in the request payload only when set; both single and bulk sends covered.
- README: add a short template + language example.
